### PR TITLE
Feat/page header 구현

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,5 +12,6 @@
       2,
       { "namedComponents": ["arrow-function", "function-declaration"] },
     ],
+    "react/require-default-props": "off",
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.2",
         "react-scripts": "5.0.1",
         "redux": "^5.0.1",
         "styled-components": "^6.1.13",
@@ -3339,6 +3340,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15204,6 +15213,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "dependencies": {
+        "@remix-run/router": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "dependencies": {
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2",
     "react-scripts": "5.0.1",
     "redux": "^5.0.1",
     "styled-components": "^6.1.13",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,31 @@
 import { Reset } from 'styled-reset';
 import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Home from './views/Home.tsx';
+import Board from './views/Board.tsx';
+import Bulletin from './views/Bulletin.tsx';
+import Join from './views/Join.tsx';
+import Login from './views/Login.tsx';
+import Notification from './views/Notification.tsx';
+import Setting from './views/Setting.tsx';
+import Writing from './views/Writing.tsx';
 
 function App() {
   return (
     <div className="App">
       <Reset />
-      <div>Hi, I am app</div>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/join" element={<Join />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/board" element={<Board />} />
+          <Route path="/board/setting" element={<Setting />} />
+          <Route path="/bulletin" element={<Bulletin />} />
+          <Route path="/bulletin/Writing" element={<Writing />} />
+          <Route path="/notification" element={<Notification />} />
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </BrowserRouter>
     </div>
   );
 }

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link, useLocation } from 'react-router-dom';
+
+const BreadcrumbsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  margin-bottom: 8px;
+`;
+
+// 게시판에 글 조회 시 수정 필요
+const validPathname = (pathname: string) => {
+  if (pathname === '') return '홈';
+  if (pathname === 'board') return '보드';
+  if (pathname === 'setting') return '설정';
+  if (pathname === 'writing') return '글쓰기';
+  if (pathname === 'bulletin') return '게시판';
+  if (pathname === 'writing') return '게시판';
+  return '특수처리';
+};
+
+const Separator = styled.span`
+  margin: 0 5px;
+`;
+
+const Breadcrumb = styled.span<{ $isLast?: boolean }>`
+  font-size: 14px;
+  color: ${({ $isLast }) => ($isLast ? 'black' : 'rgba(0, 0, 0, 0.6)')};
+`;
+
+const BreadcrumbLink = styled(Link)<{ $isLast?: boolean }>`
+  cursor: pointer;
+  font-size: 14px;
+  color: ${({ $isLast }) => ($isLast ? 'black' : 'rgba(0, 0, 0, 0.6)')};
+  text-decoration: none;
+
+  &:hover {
+    color: black;
+  }
+`;
+
+export default function Breadcrumbs() {
+  const location = useLocation();
+  const { pathname } = location;
+  const segments = pathname.split('/');
+  let url = 'http://localhost:3000';
+
+  return (
+    <BreadcrumbsContainer>
+      {pathname === '/' ? (
+        <BreadcrumbLink to="/" $isLast>
+          홈
+        </BreadcrumbLink>
+      ) : (
+        segments.map((segment: string, index: number) => {
+          const result = validPathname(segment);
+          if (index > 0) {
+            url += `/${segment}`;
+          }
+          const isLast = index === segments.length - 1;
+
+          return (
+            <React.Fragment key={url}>
+              {index !== 0 && <Separator> / </Separator>}
+              {result !== '특수처리' ? (
+                <BreadcrumbLink to={url} $isLast={isLast}>
+                  {result}
+                </BreadcrumbLink>
+              ) : (
+                <Breadcrumb $isLast={isLast}>{result}</Breadcrumb>
+              )}
+            </React.Fragment>
+          );
+        })
+      )}
+    </BreadcrumbsContainer>
+  );
+}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+import Breadcrumbs from './Breadcrumbs.tsx';
+
+interface PageHeaderTitleProps {
+  title: string;
+  fontSize?: number;
+  fontWeight?: number;
+}
+
+const PageHeaderTitleContainer = styled.div<{
+  fontSize: number;
+  fontWeight: number;
+}>`
+  width: fit-content;
+  font-size: ${props => `${props.fontSize}px`};
+  font-weight: ${props => props.fontWeight};
+`;
+
+export default function PageHeader({
+  title,
+  fontSize = 24,
+  fontWeight = 500,
+}: PageHeaderTitleProps) {
+  return (
+    <div>
+      <Breadcrumbs />
+      <PageHeaderTitleContainer fontSize={fontSize} fontWeight={fontWeight}>
+        {title}
+      </PageHeaderTitleContainer>
+    </div>
+  );
+}

--- a/src/views/Board.tsx
+++ b/src/views/Board.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import PageHeader from '../components/PageHeader.tsx';
+
+export default function Board() {
+  return (
+    <div>
+      <PageHeader title="제목" />
+      Board
+    </div>
+  );
+}

--- a/src/views/Board.tsx
+++ b/src/views/Board.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import PageHeader from '../components/PageHeader.tsx';
 
 export default function Board() {
-  return (
-    <div>
-      <PageHeader title="제목" />
-      Board
-    </div>
-  );
+  return <div>Board</div>;
 }

--- a/src/views/Bulletin.tsx
+++ b/src/views/Bulletin.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Bulletin() {
+  return <div>Bulletin</div>;
+}

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Home() {
+  return <div>홈</div>;
+}

--- a/src/views/Join.tsx
+++ b/src/views/Join.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Join() {
+  return <div>Join</div>;
+}

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Login() {
+  return <div>Login</div>;
+}

--- a/src/views/Notification.tsx
+++ b/src/views/Notification.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Notification() {
+  return <div>Notification</div>;
+}

--- a/src/views/Setting.tsx
+++ b/src/views/Setting.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Setting() {
+  return <div>Setting</div>;
+}

--- a/src/views/Writing.tsx
+++ b/src/views/Writing.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Writing() {
+  return <div>Writing</div>;
+}


### PR DESCRIPTION
- [ ]  유진님
- [ ]  지선님

페이지 헤더를 만들어 주는 컴포넌트 입니다

상단에 BreadCrumb를 클릭하면 해당 페이지로 이동이 가능합니다
BreadCrumb는 url에 따라 자동으로 생성이 됩니다

BreadCrumb 테스트를 위해 App.tsx에 라우트를 임시로 설정해두었습니다. 

|제목|필수|타입|설명
|---|----|---|---|
|title|필수|string|pageHeader 제목|
|fontSize|선택|number|pageHeader의 폰트 크기 조절, 디폴트는 24px 입니다|
|fontWeight|선택|number|pageHeader의 폰트 두께 조절. 디폴트는 500 입니다|

사용 예시

*게시판 / 글쓰기 
<img width="371" alt="스크린샷 2024-10-11 오후 12 36 52" src="https://github.com/user-attachments/assets/920115b3-6d20-42f6-b60e-68f4f02e5bfa">

<img width="506" alt="스크린샷 2024-10-11 오후 12 36 57" src="https://github.com/user-attachments/assets/263a75fd-15bd-4223-8fdb-9d6702e86f45">


